### PR TITLE
chore(blog): allow building with standard hugo

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "camunda-commons-ui": "camunda/camunda-commons-ui#master",
     "grunt": "0.4.5",
     "grunt-browserify": "4.0.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-copy": "0.8.0",
     "grunt-contrib-cssmin": "0.13.0",

--- a/theme-src/layouts/partials/header.html
+++ b/theme-src/layouts/partials/header.html
@@ -16,6 +16,8 @@
 
   {{ if le .Hugo.Version "0.17.0" }}
   {{ if .RSSlink }}<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}
+  {{ else }}
+  {{ if .RSSLink }}<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}
   {{ end }}
 
   {{ .Hugo.Generator }}

--- a/theme-src/layouts/partials/header.html
+++ b/theme-src/layouts/partials/header.html
@@ -14,7 +14,9 @@
 
   <link rel="canonical" href="{{ .Permalink }}">
 
+  {{ if le .Hugo.Version "0.17.0" }}
   {{ if .RSSlink }}<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}
+  {{ end }}
 
   {{ .Hugo.Generator }}
 

--- a/themes/blogcamundaorg/layouts/partials/header.html
+++ b/themes/blogcamundaorg/layouts/partials/header.html
@@ -14,7 +14,11 @@
 
   <link rel="canonical" href="{{ .Permalink }}">
 
+  {{ if le .Hugo.Version "0.17.0" }}
   {{ if .RSSlink }}<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}
+  {{ else }}
+  {{ if .RSSLink }}<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}
+  {{ end }}
 
   {{ .Hugo.Generator }}
 


### PR DESCRIPTION
* workaround #37 by checking the hugo version before including
  RSS feed. This should not impact generation on CI (?), as we
  use our custom, monkeypatched hugo there?
* add grunt-cli as dependency so that `npm run dev` just works for all users.

__NOTE:__ This should be reviewed by someone using Windows with the custom hugo configured to see if bundling still works as expected.