### PR TITLE
Add user survey announcement post to Camunda blog

### DIFF
--- a/content/post/2018/07/microservices-orchestration-survey-2018.md
+++ b/content/post/2018/07/microservices-orchestration-survey-2018.md
@@ -1,0 +1,35 @@
++++
+title = "We've Opened the 2018 Microservices Orchestration Survey, and We're Looking For Your Input"
+description = "Share your perspective on how you and your organization manage complex, cross-service business processes as software architectures evolve and become more decoupled."
+date = "2018-07-09T09:00:00+01:00"
+author = "Mike Winters"
+categories = ["Announcements"]
+tags = ["user surveys", "microservices orchestration"]
++++
+
+_This post also appeared on the [Zeebe blog](https://zeebe.io/blog/2018/07/microservices-orchestration-survey-2018/)._
+
+In recent months, we’ve seen more and more users building solutions with Camunda BPM to address microservices orchestration challenges. The [external task clients](https://docs.camunda.org/manual/7.9/user-guide/ext-client/), newly added in version 7.9.0, is one example of how Camunda BPM has evolved to meet user needs in this area.
+
+Camunda is running a survey about microservices orchestration so that we can learn more about how you’re approaching this problem and how Camunda can help. We’d love to hear your feedback.
+
+**[You can submit your response to the survey here.](https://www.surveygizmo.com/s3/4451284/2fe4fb27f1d7)**
+
+Every organization takes a different approach to a microservices architecture, and we want to be sure we have a detailed understanding of what microservices orchestration means to the range of different types of users who are thinking about this problem.
+
+For example, some organizations build _all_ of their applications based on a microservices architecture and have always operated that way, while others have a mix of microservices-based applications as well as applications that rely on some more traditional architecture. Some organizations connect their microservices with an asynchronous, event-driven communication pattern, while others use synchronous, HTTP-based communication.
+
+The survey is open to anyone with interest in this topic! You don't need to be a Camunda user, and you don't even need to be a part of team that's working with a microservices architecture. We still want to hear from you.
+
+After collecting responses, we'll publish a report summarizing the survey results. We'll only include aggregated data in this report–no individual response data.
+
+Here are a few other details:
+• The survey will remain open until July 30, 2018.
+• It's possible to respond to the survey anonymously if you'd like.
+• Almost all questions in the survey are optional, so you can skip questions you prefer not to answer.
+
+As a token of our appreciation, we'll be drawing names of a few respondents to give away free passes to your choice of [CamundaCon 2018 in Berlin](https://camunda.com/events/camundacon/) (our annual user conference) or a [Camunda classroom training](https://camunda.com/services/training/), where you'll learn more about Camunda BPM and BPMN.
+
+We hope to [hear from you](https://www.surveygizmo.com/s3/4451284/2fe4fb27f1d7), and we'll report back once we've analyzed the survey results.
+
+<link rel="canonical" href="https://zeebe.io/blog/2018/07/microservices-orchestration-survey-2018/">


### PR DESCRIPTION
@meyerdan @menski I'd like to add a post to the Camunda blog announcing the microservices orchestration survey and pointing users to where they can complete it. 

Let me know if this looks OK--for reference, I posted a nearly-identical update on the Zeebe blog (https://zeebe.io/blog/2018/07/microservices-orchestration-survey-2018/). 